### PR TITLE
Include lxml in test requirements

### DIFF
--- a/requirements_tests.pip
+++ b/requirements_tests.pip
@@ -1,2 +1,3 @@
 -r requirements.pip
 mock
+lxml


### PR DESCRIPTION
lxml is missing from requirements_test.pip so a clean clone of the repo won't run the test suite. This adds it.
